### PR TITLE
calling attributes on nil

### DIFF
--- a/lib/metaschema/code_type.rb
+++ b/lib/metaschema/code_type.rb
@@ -8,7 +8,7 @@ require_relative "insert_type"
 module Metaschema
   class CodeType < Lutaml::Model::Serializable
     attribute :content, :string
-    attribute :class, :string
+    attribute :klass, :string
     attribute :a, AnchorType, collection: true
     attribute :insert, InsertType, collection: true
     attribute :br, :string, collection: true
@@ -27,7 +27,7 @@ module Metaschema
       namespace "http://csrc.nist.gov/ns/oscal/metaschema/1.0"
 
       map_content to: :content
-      map_attribute "class", to: :class
+      map_attribute "class", to: :klass
       map_element "a", to: :a
       map_element "insert", to: :insert
       map_element "br", to: :br

--- a/lib/metaschema/remarks_type.rb
+++ b/lib/metaschema/remarks_type.rb
@@ -10,7 +10,7 @@ require_relative "table_type"
 
 module Metaschema
   class RemarksType < Lutaml::Model::Serializable
-    attribute :class, :string
+    attribute :klass, :string
     attribute :h1, InlineMarkupType, collection: true
     attribute :h2, InlineMarkupType, collection: true
     attribute :h3, InlineMarkupType, collection: true
@@ -30,7 +30,7 @@ module Metaschema
       root "RemarksType"
       namespace "http://csrc.nist.gov/ns/oscal/metaschema/1.0"
 
-      map_attribute "class", to: :class
+      map_attribute "class", to: :klass
       map_element "h1", to: :h1
       map_element "h2", to: :h2
       map_element "h3", to: :h3


### PR DESCRIPTION
Fix failures due to calling attributes on nil.
We were overriding the default `class` method for the instance.

fix #5 