### PR TITLE
fix: update Canon gem API usage for spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,11 +21,8 @@ Lutaml::Model::Config.configure do |config|
   config.xml_adapter_type = :nokogiri
 end
 
-Canon::RSpecMatchers.configure do |config|
+Canon::Config.configure do |config|
   # Use spec_friendly profile which ignores comments and formatting differences
   # that don't affect semantic equivalence
-  config.xml_match_profile = :spec_friendly
-
-  # Only show normative (semantically significant) diffs, hide informational
-  config.diff_mode = :normative
+  config.xml.match.profile = :spec_friendly
 end


### PR DESCRIPTION
## Summary

Fix Canon gem API usage in spec_helper.rb. The `Canon::RSpecMatchers.configure`
method was removed in a recent Canon gem update. This updates to use the current
`Canon::Config.configure` API with `config.xml.match.profile` instead.

Also removes the invalid `config.diff_mode = :normative` setting, as `:normative`
is not a valid value for diff_mode (valid values are `:by_line`, `:by_object`,
`:pretty_diff`).

## Test plan

- [x] All 146 metaschema tests pass locally
- [x] Compatible with Canon gem 0.2.x API